### PR TITLE
store forecast temp_max when it is less than 1

### DIFF
--- a/openweather.coffee
+++ b/openweather.coffee
@@ -317,7 +317,7 @@ module.exports = (env) ->
           temp_max = -Infinity
           if result.list[@arrayday].temp.min <= temp_min
             temp_min = result.list[@arrayday].temp.min
-          if result.list[@arrayday].temp.max >= temp_max?
+          if result.list[@arrayday].temp.max >= temp_max
             temp_max = result.list[@arrayday].temp.max
 
           @_setAttribute "low", @_toFixed(temp_min, 1)


### PR DESCRIPTION
There is a small typo which prevents the max temp value from getting stored properly, when it is less than 1°C. temp_max? evaluates to true, which compares as 1.